### PR TITLE
Ensure correct line ending for varnish start file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+start  eol=lf


### PR DESCRIPTION
As mentined in #1, this fixes an issue with starting the varnish container on Windows because of incorrect CRLF line endings (if `core.autocrlf` is enabled).